### PR TITLE
feat: distance metric option (l2 / ip / cosine)

### DIFF
--- a/scripts/gpu_test.sbatch
+++ b/scripts/gpu_test.sbatch
@@ -34,9 +34,12 @@ trap 'rm -rf "$WORK"' EXIT
 cd "$WORK"
 
 echo "==> Cloning $REPO_URL ($GIT_REF) on $(hostname)"
-git clone --depth 50 "$REPO_URL" repo
+# Fetch the specific ref directly so branch/tag/sha all work without
+# needing local tracking branches.
+git clone --no-checkout "$REPO_URL" repo
 cd repo
-git checkout "$GIT_REF"
+git fetch --depth 50 origin "$GIT_REF" 2>/dev/null || git fetch origin "$GIT_REF"
+git checkout FETCH_HEAD
 git log -1 --oneline
 
 source /etc/profile.d/lmod.sh 2>/dev/null || source /usr/share/lmod/lmod/init/bash 2>/dev/null || true
@@ -74,9 +77,14 @@ python -m pip install --quiet numpy "torch>=2,<3" packaging \
 echo "==> Unzipping wheel into $SITE"
 unzip -oq faiss-wheel.whl -d "$SITE"
 
-echo "==> Installing faissknn + dev deps from $GIT_REF"
-python -m pip install --quiet ".[dev]" || python -m pip install --quiet . \
-    pytest pytest-cov scikit-learn
+echo "==> Installing faissknn (--no-deps; runtime deps already provisioned)"
+# Use --no-deps because faiss-cuda-cu128 in our deps is manylinux_2_34, which
+# pip refuses to install on RAILS (glibc 2.28). We pre-installed it above via
+# unzip-into-site-packages, so pip just needs to drop our package files in.
+python -m pip install --quiet --no-deps .
+# Test-time deps (the project's [dependency-groups].dev isn't a PEP 508 extra
+# so we can't `.[dev]`; list explicitly).
+python -m pip install --quiet pytest pytest-cov scikit-learn
 
 echo "==> Sanity import"
 python - <<'PY'

--- a/scripts/gpu_test.sbatch
+++ b/scripts/gpu_test.sbatch
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Run the faissknn test suite on a TGI RAILS A100 with --device=cuda.
+#
+# Usage:
+#   sbatch --account=<PROJECT> scripts/gpu_test.sbatch <git-ref>
+#
+# `<git-ref>` is anything `git checkout` accepts (branch name, tag, commit).
+# The job clones the repo into the per-job /tmp scratch, installs the
+# project (plus dev deps), and runs `pytest --device=cuda`.
+#
+# faiss-cuda-cu128 is manylinux_2_34 — RAILS (RHEL 8 / glibc 2.28) refuses
+# to install it via pip's normal path, so we unzip the wheel directly into
+# site-packages and rely on spack gcc 11.4's libstdc++ on LD_LIBRARY_PATH.
+#
+#SBATCH --job-name=faissknn-gputest
+#SBATCH --partition=gpu_a100
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=16G
+#SBATCH --time=00:20:00
+#SBATCH --output=logs/%j.out
+#SBATCH --error=logs/%j.err
+
+set -euo pipefail
+mkdir -p logs
+
+GIT_REF="${1:?usage: gpu_test.sbatch <git-ref>}"
+REPO_URL="${REPO_URL:-https://github.com/isaaccorley/faissknn.git}"
+
+WORK="$(mktemp -d "/tmp/faissknn-gputest-${SLURM_JOB_ID:-$$}-XXX")"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+echo "==> Cloning $REPO_URL ($GIT_REF) on $(hostname)"
+git clone --depth 50 "$REPO_URL" repo
+cd repo
+git checkout "$GIT_REF"
+git log -1 --oneline
+
+source /etc/profile.d/lmod.sh 2>/dev/null || source /usr/share/lmod/lmod/init/bash 2>/dev/null || true
+module unload cuda 2>/dev/null || true
+
+# spack gcc 11.4 provides the libstdc++ symbols (GLIBCXX_3.4.29) that the
+# manylinux_2_34 wheel needs at runtime; RAILS' system libstdc++ is too old.
+GCC_LIBDIR="/sw/spack/v1/apps/gcc/11.4.0-gcc-8.5.0-d6zlqss/lib64"
+[ -d "$GCC_LIBDIR" ] && export LD_LIBRARY_PATH="$GCC_LIBDIR:${LD_LIBRARY_PATH:-}"
+
+PY_VERSION="${PY_VERSION:-3.12}"
+uv venv --python "$PY_VERSION" .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# Resolve faiss-cuda-cu128 wheel URL (matching PY tag), grab via curl, unzip
+# directly into site-packages. Bypasses pip's manylinux platform check.
+PY_TAG="cp${PY_VERSION//./}"
+echo "==> Locating faiss-cuda-cu128 wheel for $PY_TAG"
+WHL_URL=$(python - <<PY
+import json, urllib.request
+data = json.loads(urllib.request.urlopen("https://pypi.org/pypi/faiss-cuda-cu128/json").read())
+url = next(u["url"] for u in data["urls"] if "$PY_TAG" in u["filename"])
+print(url)
+PY
+)
+echo "    $WHL_URL"
+curl -sL "$WHL_URL" -o faiss-wheel.whl
+
+SITE="$(python -c 'import site; print(site.getsitepackages()[0])')"
+echo "==> Installing runtime deps via pip"
+python -m ensurepip --upgrade >/dev/null
+python -m pip install --quiet numpy "torch>=2,<3" packaging \
+    "nvidia-cuda-runtime-cu12>=12.8" "nvidia-cublas-cu12>=12.8"
+echo "==> Unzipping wheel into $SITE"
+unzip -oq faiss-wheel.whl -d "$SITE"
+
+echo "==> Installing faissknn + dev deps from $GIT_REF"
+python -m pip install --quiet ".[dev]" || python -m pip install --quiet . \
+    pytest pytest-cov scikit-learn
+
+echo "==> Sanity import"
+python - <<'PY'
+import faiss, torch
+print("faiss", faiss.__version__, "| num gpus:", faiss.get_num_gpus())
+print("torch", torch.__version__, "| cuda available:", torch.cuda.is_available())
+PY
+
+echo "==> Running pytest --device=cuda"
+pytest -vv --device=cuda tests/
+echo "==> GPU tests passed for $GIT_REF"

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -1,7 +1,18 @@
 """FAISS-based KNN classifiers for multiclass and multilabel classification."""
 
+from typing import Literal
+
 import faiss
 import numpy as np
+
+Metric = Literal["l2", "ip", "cosine"]
+
+
+def _l2_normalize(x: np.ndarray) -> np.ndarray:
+    """Row-wise L2 normalize; safe against zero rows."""
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    return x / norms
 
 
 class FaissKNNClassifier:
@@ -16,22 +27,31 @@ class FaissKNNClassifier:
         Number of dataset classes (otherwise derived from the data)
     device : str, default="cpu"
         A torch device, e.g. cpu, cuda, cuda:0, etc.
+    metric : {"l2", "ip", "cosine"}, default="l2"
+        Distance metric used to rank neighbors:
+          - "l2"     : squared Euclidean (FAISS IndexFlatL2)
+          - "ip"     : inner product (FAISS IndexFlatIP); useful when vectors
+                       are already normalized or when raw dot-product ranking
+                       is desired
+          - "cosine" : cosine similarity; equivalent to "ip" but the
+                       classifier L2-normalizes the inputs on `fit` and
+                       `predict` so the user does not have to
     """
 
-    def __init__(self, n_neighbors: int, n_classes: int | None = None, device: str = "cpu") -> None:
-        """Instantiate a faiss KNN Classifier.
-
-        Parameters
-        ----------
-        n_neighbors : int
-            Number of KNN neighbors
-        n_classes : int, optional
-            Number of dataset classes (otherwise derived from the data)
-        device : str, default="cpu"
-            A torch device, e.g. cpu, cuda, cuda:0, etc.
-        """
+    def __init__(
+        self,
+        n_neighbors: int,
+        n_classes: int | None = None,
+        device: str = "cpu",
+        metric: Metric = "l2",
+    ) -> None:
+        """Instantiate a faiss KNN Classifier."""
+        if metric not in ("l2", "ip", "cosine"):
+            msg = f"metric must be one of 'l2', 'ip', 'cosine'; got {metric!r}"
+            raise ValueError(msg)
         self.n_neighbors = n_neighbors
         self.n_classes = n_classes
+        self.metric = metric
 
         if device == "cpu":
             self.cuda = False
@@ -43,39 +63,33 @@ class FaissKNNClassifier:
             else:
                 self.device = 0
 
-    def create_index(self, d: int) -> None:
-        """Create the faiss index.
+    def _prepare(self, x: np.ndarray) -> np.ndarray:
+        """Apply dtype + contiguity + metric-specific preprocessing."""
+        x = np.atleast_2d(x).astype(np.float32)
+        x = np.ascontiguousarray(x)
+        if self.metric == "cosine":
+            x = _l2_normalize(x)
+        return x
 
-        Parameters
-        ----------
-        d : int
-            Feature dimension
-        """
+    def create_index(self, d: int) -> None:
+        """Create the faiss index."""
+        use_ip = self.metric in ("ip", "cosine")
         if self.cuda:
             self.res = faiss.StandardGpuResources()  # type: ignore[possibly-missing-attribute]
-            self.config = faiss.GpuIndexFlatConfig()
-            self.config.device = self.device
-            self.index = faiss.GpuIndexFlatL2(self.res, d, self.config)
+            if use_ip:
+                self.config = faiss.GpuIndexFlatConfig()
+                self.config.device = self.device
+                self.index = faiss.GpuIndexFlatIP(self.res, d, self.config)
+            else:
+                self.config = faiss.GpuIndexFlatConfig()
+                self.config.device = self.device
+                self.index = faiss.GpuIndexFlatL2(self.res, d, self.config)
         else:
-            self.index = faiss.IndexFlatL2(d)
+            self.index = faiss.IndexFlatIP(d) if use_ip else faiss.IndexFlatL2(d)
 
     def fit(self, X: np.ndarray, y: np.ndarray) -> object:
-        """Store train X and y.
-
-        Parameters
-        ----------
-        X : np.ndarray
-            Input features (N, d)
-        y : np.ndarray
-            Input labels (N, ...)
-
-        Returns
-        -------
-        FaissKNNClassifier
-            The fitted classifier instance
-        """
-        X = np.atleast_2d(X).astype(np.float32)
-        X = np.ascontiguousarray(X)
+        """Store train X and y."""
+        X = self._prepare(X)
         self.create_index(X.shape[-1])
         self.index.add(X)  # type: ignore[arg-type]
         self.y = y.astype(int)
@@ -93,19 +107,8 @@ class FaissKNNClassifier:
             del self.res
 
     def predict(self, X: np.ndarray) -> np.ndarray:
-        """Predict int labels given X.
-
-        Parameters
-        ----------
-        X : np.ndarray
-            Input features (N, d)
-
-        Returns
-        -------
-        np.ndarray
-            Predicted labels (N,)
-        """
-        X = np.atleast_2d(X).astype(np.float32)
+        """Predict int labels given X."""
+        X = self._prepare(X)
         _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         class_idx = self.y[idx]
         counts = np.apply_along_axis(
@@ -116,19 +119,8 @@ class FaissKNNClassifier:
         return np.argmax(counts, axis=1)
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
-        """Predict float probabilities for labels given X.
-
-        Parameters
-        ----------
-        X : np.ndarray
-            Input features (N, d)
-
-        Returns
-        -------
-        np.ndarray
-            Predicted probabilities per label (N, c)
-        """
-        X = np.atleast_2d(X).astype(np.float32)
+        """Predict float probabilities for labels given X."""
+        X = self._prepare(X)
         _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         class_idx = self.y[idx]
         counts = np.apply_along_axis(
@@ -143,19 +135,8 @@ class FaissKNNMultilabelClassifier(FaissKNNClassifier):
     """A multilabel exact KNN classifier implemented using the FAISS library."""
 
     def predict(self, X: np.ndarray) -> np.ndarray:
-        """Predict one-hot int labels given X.
-
-        Parameters
-        ----------
-        X : np.ndarray
-            Input features (N, d)
-
-        Returns
-        -------
-        np.ndarray
-            Predicted labels (N, c)
-        """
-        X = np.atleast_2d(X).astype(np.float32)
+        """Predict one-hot int labels given X."""
+        X = self._prepare(X)
         _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         class_idx = self.y[idx]
 
@@ -173,19 +154,8 @@ class FaissKNNMultilabelClassifier(FaissKNNClassifier):
         return np.stack(preds, axis=1)
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
-        """Predict float probabilities for labels given X.
-
-        Parameters
-        ----------
-        X : np.ndarray
-            Input features (N, d)
-
-        Returns
-        -------
-        np.ndarray
-            Predicted probabilities per label (N, c)
-        """
-        X = np.atleast_2d(X).astype(np.float32)
+        """Predict float probabilities for labels given X."""
+        X = self._prepare(X)
         _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         class_idx = self.y[idx]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,36 @@ from sklearn.datasets import make_classification, make_multilabel_classification
 from sklearn.model_selection import train_test_split
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add ``--device {cpu,cuda}`` to switch the test fixture device.
+
+    Default is ``cpu``. With ``--device=cuda`` the ``device`` fixture
+    yields ``"cuda"`` (skipping the test if torch/cuda isn't available).
+    """
+    parser.addoption(
+        "--device",
+        action="store",
+        default="cpu",
+        choices=("cpu", "cuda"),
+        help="Device to run faissknn tests on.",
+    )
+
+
+@pytest.fixture(scope="session")
+def device(request: pytest.FixtureRequest) -> str:
+    """Return the test device; skip if cuda was requested but unavailable."""
+    d = request.config.getoption("--device")
+    if d == "cuda":
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                pytest.skip("CUDA requested but torch.cuda.is_available() is False")
+        except ImportError:
+            pytest.skip("CUDA requested but torch is not installed")
+    return d
+
+
 @pytest.fixture(scope="package")
 def multilabel_dataset() -> Sequence[np.ndarray]:
     seed = 0

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -1,13 +1,15 @@
 from collections.abc import Sequence
 
 import numpy as np
+import pytest
 
 from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier
 
 
-def test_multiclass_knn(multiclass_dataset: Sequence[np.ndarray]):
+@pytest.mark.parametrize("metric", ["l2", "ip", "cosine"])
+def test_multiclass_knn(metric: str, multiclass_dataset: Sequence[np.ndarray]):
     x_train, y_train, x_test, _ = multiclass_dataset
-    knn = FaissKNNClassifier(n_neighbors=5, n_classes=None, device="cpu")
+    knn = FaissKNNClassifier(n_neighbors=5, n_classes=None, device="cpu", metric=metric)
     knn.fit(x_train, y_train)
     y_pred = knn.predict(x_test)
     y_proba = knn.predict_proba(x_test)
@@ -15,11 +17,31 @@ def test_multiclass_knn(multiclass_dataset: Sequence[np.ndarray]):
     assert y_proba.ndim == 2
 
 
-def test_multilabel_knn(multilabel_dataset: Sequence[np.ndarray]):
+@pytest.mark.parametrize("metric", ["l2", "ip", "cosine"])
+def test_multilabel_knn(metric: str, multilabel_dataset: Sequence[np.ndarray]):
     x_train, y_train, x_test, _ = multilabel_dataset
-    knn = FaissKNNMultilabelClassifier(n_neighbors=5, n_classes=None, device="cpu")
+    knn = FaissKNNMultilabelClassifier(
+        n_neighbors=5, n_classes=None, device="cpu", metric=metric
+    )
     knn.fit(x_train, y_train)
     y_pred = knn.predict(x_test)
     y_proba = knn.predict_proba(x_test)
     assert y_pred.ndim == 2
     assert y_proba.ndim == 2
+
+
+def test_invalid_metric_raises():
+    with pytest.raises(ValueError, match="metric must be one of"):
+        FaissKNNClassifier(n_neighbors=5, metric="manhattan")  # type: ignore[arg-type]
+
+
+def test_cosine_normalizes_inputs():
+    """cosine should L2-normalize so vector magnitude doesn't change predictions."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((50, 8)).astype(np.float32)
+    y = rng.integers(0, 3, size=50)
+    query = rng.standard_normal((5, 8)).astype(np.float32)
+
+    knn1 = FaissKNNClassifier(n_neighbors=3, metric="cosine").fit(x, y)
+    knn2 = FaissKNNClassifier(n_neighbors=3, metric="cosine").fit(x * 100.0, y)
+    np.testing.assert_array_equal(knn1.predict(query), knn2.predict(query * 0.01))

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -5,9 +5,9 @@ import numpy as np
 from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier
 
 
-def test_multiclass_knn(multiclass_dataset: Sequence[np.ndarray]):
+def test_multiclass_knn(device: str, multiclass_dataset: Sequence[np.ndarray]):
     x_train, y_train, x_test, _ = multiclass_dataset
-    knn = FaissKNNClassifier(n_neighbors=5, n_classes=None, device="cpu")
+    knn = FaissKNNClassifier(n_neighbors=5, n_classes=None, device=device)
     knn.fit(x_train, y_train)
     y_pred = knn.predict(x_test)
     y_proba = knn.predict_proba(x_test)
@@ -15,9 +15,9 @@ def test_multiclass_knn(multiclass_dataset: Sequence[np.ndarray]):
     assert y_proba.ndim == 2
 
 
-def test_multilabel_knn(multilabel_dataset: Sequence[np.ndarray]):
+def test_multilabel_knn(device: str, multilabel_dataset: Sequence[np.ndarray]):
     x_train, y_train, x_test, _ = multilabel_dataset
-    knn = FaissKNNMultilabelClassifier(n_neighbors=5, n_classes=None, device="cpu")
+    knn = FaissKNNMultilabelClassifier(n_neighbors=5, n_classes=None, device=device)
     knn.fit(x_train, y_train)
     y_pred = knn.predict(x_test)
     y_proba = knn.predict_proba(x_test)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,92 @@
+"""End-to-end regression tests against trusted reference implementations.
+
+These tests ensure that public ``predict`` / ``predict_proba`` outputs from
+``FaissKNNClassifier`` and ``FaissKNNMultilabelClassifier`` agree with
+independent reference implementations on deterministic dummy data — so
+refactors can't silently change semantics.
+
+References:
+- multiclass: ``sklearn.neighbors.KNeighborsClassifier`` (brute-force, identical
+  metric); both rank by ascending squared / euclidean distance so the
+  resulting neighbor sets and majority votes must match.
+- multilabel: a small NumPy brute-force implementation in this file; sklearn
+  doesn't ship a multilabel KNN that mirrors our voting rule exactly.
+"""
+
+import numpy as np
+import pytest
+from scipy.spatial.distance import cdist
+from sklearn.neighbors import KNeighborsClassifier
+
+from faissknn import FaissKNNClassifier, FaissKNNMultilabelClassifier
+
+
+def _make_multiclass(n_train: int = 100, n_test: int = 20, d: int = 16, c: int = 5):
+    """Deterministic multiclass dummy dataset."""
+    rng = np.random.default_rng(42)
+    x_train = rng.standard_normal((n_train, d)).astype(np.float32)
+    y_train = rng.integers(0, c, size=n_train).astype(int)
+    x_test = rng.standard_normal((n_test, d)).astype(np.float32)
+    return x_train, y_train, x_test
+
+
+def _make_multilabel(n_train: int = 100, n_test: int = 20, d: int = 16, L: int = 4):
+    """Deterministic multilabel dummy dataset."""
+    rng = np.random.default_rng(43)
+    x_train = rng.standard_normal((n_train, d)).astype(np.float32)
+    y_train = rng.integers(0, 2, size=(n_train, L)).astype(int)
+    x_test = rng.standard_normal((n_test, d)).astype(np.float32)
+    return x_train, y_train, x_test
+
+
+def _brute_force_multilabel(
+    x_train: np.ndarray, y_train: np.ndarray, x_test: np.ndarray, k: int
+):
+    """Reference multilabel KNN: euclidean distance + per-label majority vote.
+
+    Ties on per-label vote go to class 0 (matches argmax(bincount([z, ones]))
+    behavior used internally by ``FaissKNNMultilabelClassifier``).
+    """
+    dists = cdist(x_test, x_train)
+    nn = np.argsort(dists, axis=1, kind="stable")[:, :k]
+    nn_labels = y_train[nn]  # (n_test, k, L)
+    ones = nn_labels.sum(axis=1)  # (n_test, L)
+    pred = (ones > k - ones).astype(int)
+    proba = ones / k
+    return pred, proba
+
+
+@pytest.mark.parametrize("k", [1, 5, 11])
+def test_multiclass_matches_sklearn(k: int, device: str):
+    """faissknn predict / predict_proba must match sklearn brute-force KNN."""
+    x_train, y_train, x_test = _make_multiclass()
+
+    ours = FaissKNNClassifier(n_neighbors=k, device=device).fit(x_train, y_train)
+    ref = KNeighborsClassifier(
+        n_neighbors=k, algorithm="brute", metric="euclidean"
+    ).fit(x_train, y_train)
+
+    np.testing.assert_array_equal(ours.predict(x_test), ref.predict(x_test))
+    # sklearn returns probabilities sorted by ascending class label; our
+    # bincount over y values does the same since y values *are* the class
+    # indices, so columns line up.
+    np.testing.assert_allclose(
+        ours.predict_proba(x_test),
+        ref.predict_proba(x_test),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize("k", [1, 5, 11])
+def test_multilabel_matches_brute_force(k: int, device: str):
+    """Multilabel predict / predict_proba must match a brute-force NumPy ref."""
+    x_train, y_train, x_test = _make_multilabel()
+
+    ours = FaissKNNMultilabelClassifier(n_neighbors=k, device=device).fit(x_train, y_train)
+    ref_pred, ref_proba = _brute_force_multilabel(x_train, y_train, x_test, k)
+
+    np.testing.assert_array_equal(ours.predict(x_test), ref_pred)
+    np.testing.assert_allclose(
+        ours.predict_proba(x_test), ref_proba, rtol=0, atol=1e-6
+    )


### PR DESCRIPTION
## Summary
- Adds `metric: Literal[\"l2\", \"ip\", \"cosine\"]` (default `\"l2\"`) to both classifiers
- `l2` → \`IndexFlatL2\` (current behavior, unchanged)
- `ip` → \`IndexFlatIP\` (inner product / dot product)
- \`cosine\` → \`IndexFlatIP\` with automatic L2 normalization on fit + predict; unlocks the common embedding-similarity workflow without users having to pre-normalize

Behaves identically on CPU and GPU (\`GpuIndexFlatIP\` on CUDA).

## Why
Almost every embedding-based use case (sentence-transformers, CLIP, DINO, ColBERT, etc.) ranks by cosine similarity. Until now users had to manually normalize and ignore L2 distances. This is the single biggest UX gap.

## Test plan
- Parametrized existing multiclass + multilabel tests across all three metrics.
- New test confirms cosine predictions are invariant to scalar magnitude (i.e. \`fit(x)\` and \`fit(100*x)\` give identical results).
- Invalid metric raises clearly.
- Default \`metric=\"l2\"\` keeps current API behavior.