### PR TITLE
feat: default to faiss-cpu; CUDA backends become optional extras

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,15 +7,22 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Exercise the default install (faiss-cpu) across every OS we ship wheels
+    # for. The GPU extras (cuda / cu13) are Linux-x86_64-only and need a GPU,
+    # so they aren't installed here — see README for the manual swap recipe.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7.1
         with:
             enable-cache: true
-      - run: uv run --all-extras --dev pytest -vvv --cov=src
+      - run: uv run --dev pytest -vvv --cov=src
       - name: Report Coverage
-        run: uv run --all-extras --dev coverage report -m
+        run: uv run --dev coverage report -m
 
   pre-commit:
     runs-on: ubuntu-latest
@@ -25,4 +32,4 @@ jobs:
         with:
             enable-cache: true
       - name: pre-commit
-        run: uv run --all-extras --dev pre-commit run --all-files -v
+        run: uv run --dev pre-commit run --all-files -v

--- a/README.md
+++ b/README.md
@@ -10,25 +10,31 @@
 pip install faissknn
 ```
 
-Pulls in [`faiss-cuda-cu128`](https://pypi.org/project/faiss-cuda-cu128/) (Taylor Geospatial's GPU-enabled FAISS wheels for CUDA 12.8) along with `numpy` and `torch`. No system CUDA toolkit required — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI.
+Pulls in [`faiss-cpu`](https://pypi.org/project/faiss-cpu/) along with `numpy` and `torch`. Works everywhere — no GPU, CUDA driver, or system toolkit required.
 
-The default wheel works on:
+#### GPU acceleration (CUDA 12.x)
 
-- **CPU-only hosts** — `import faiss` succeeds, `faiss.get_num_gpus()` returns 0, all CPU index types work
-- **CUDA 12.x hosts** (NVIDIA driver R525+) — full GPU acceleration
-- **CUDA 13 hosts** (NVIDIA driver R580+) — via NVIDIA's forward-compat guarantee. You just don't get the `sm_100` (Blackwell) arch
+For GPU-enabled FAISS on CUDA 12.x hosts (NVIDIA driver R525+), install the `[cuda]` extra, which adds [`faiss-cuda-cu128`](https://pypi.org/project/faiss-cuda-cu128/) (Taylor Geospatial's GPU wheels for CUDA 12.8). No system CUDA toolkit needed — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI.
+
+```bash
+pip install "faissknn[cuda]"
+pip uninstall -y faiss-cpu
+pip install --force-reinstall faiss-cuda-cu128
+```
+
+These wheels also run on CUDA 13 hosts (driver R580+) via NVIDIA's forward-compat guarantee — you just don't get the `sm_100` (Blackwell) arch.
 
 #### Blackwell users (B100 / B200)
 
-If you need `sm_100` baked in, use the CUDA 13 wheel:
+If you need `sm_100` baked in, use the CUDA 13 wheel via the `[cu13]` extra, which adds [`faiss-cuda`](https://pypi.org/project/faiss-cuda/):
 
 ```bash
 pip install "faissknn[cu13]"
-pip uninstall -y faiss-cuda-cu128
+pip uninstall -y faiss-cpu
 pip install --force-reinstall faiss-cuda
 ```
 
-The `[cu13]` extra adds [`faiss-cuda`](https://pypi.org/project/faiss-cuda/) to the resolution, but because both packages ship the same `faiss/` module the manual uninstall+reinstall is what actually gives you a clean install. uv/pip can't auto-detect the host CUDA driver, so this is a one-time manual choice.
+Why the uninstall+reinstall? `faiss-cpu`, `faiss-cuda-cu128`, and `faiss-cuda` all ship the same `faiss/` module, so they can't cleanly coexist. The extra adds the GPU package to the resolution, but removing `faiss-cpu` and force-reinstalling is what actually gives you a clean GPU install. uv/pip can't auto-detect the host CUDA driver, so this is a one-time manual choice.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.9.3,<0.10" ]
 
 [project]
 name = "faissknn"
-version = "0.1.1"
+version = "0.2.0"
 description = "FAISS implementation of multiclass and multilabel K-Nearest Neighbors Classifiers."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -22,24 +22,25 @@ classifiers = [
 ]
 
 dependencies = [
-  # faiss-cuda-cu128 is the default backend — widest driver compatibility.
-  # It works on:
-  #   * CPU-only hosts (GPU code is unused; faiss.get_num_gpus() returns 0)
-  #   * CUDA 12.x hosts (driver R525+) — full GPU acceleration
-  #   * CUDA 13 hosts (driver R580+) — via NVIDIA forward-compat; you only
-  #     lose the sm_100 (Blackwell) arch
-  # Users with Blackwell GPUs (B100/B200) can swap to faiss-cuda for the
-  # cu13 build with sm_100 baked in; see [cu13] extra and README.
-  "faiss-cuda-cu128>=1.14.1.post1,<2",
+  # faiss-cpu is the default backend — works everywhere with no GPU, CUDA
+  # driver, or system toolkit required. For GPU acceleration, install an
+  # opt-in CUDA extra ([cuda] or [cu13]) and follow the swap recipe in the
+  # README (the CUDA wheels ship the same `faiss` module as faiss-cpu and
+  # cannot cleanly coexist, so the extra is a one-time manual choice).
+  "faiss-cpu>=1.8,<2",
   "numpy>=2,<3",
   "torch>=2,<3",
 ]
 
-# Opt-in alternate CUDA backend. uv/pip can't introspect the host CUDA
-# driver version, so this is a manual choice. faiss-cuda and faiss-cuda-cu128
-# both provide the same `faiss` Python module and cannot cleanly coexist;
-# follow the swap recipe in the README.
+# Opt-in GPU backends. uv/pip can't introspect the host CUDA driver, so the
+# choice is manual. faiss-cpu, faiss-cuda-cu128, and faiss-cuda all provide
+# the same `faiss` Python module and cannot cleanly coexist; follow the swap
+# recipe in the README.
+#   * cuda  -> faiss-cuda-cu128 (CUDA 12.8 wheels, driver R525+; also runs on
+#              CUDA 13 via NVIDIA forward-compat, minus the sm_100 arch)
+#   * cu13  -> faiss-cuda (CUDA 13 wheels with sm_100/Blackwell baked in)
 optional-dependencies.cu13 = [ "faiss-cuda>=1.14.1.post3,<2" ]
+optional-dependencies.cuda = [ "faiss-cuda-cu128>=1.14.1.post1,<2" ]
 
 [dependency-groups]
 dev = [

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -126,7 +126,9 @@ class FaissKNNClassifier:
         if self.cuda:
             self.res = faiss.StandardGpuResources()  # ty: ignore[possibly-missing-attribute]
             self.config = faiss.GpuIndexFlatConfig()  # ty: ignore[possibly-missing-attribute]
-            self.config.device = self.device
+            # In the GPU branch self.device is always an int ordinal (set in
+            # __init__); default to 0 to satisfy the typed config.device field.
+            self.config.device = self.device if isinstance(self.device, int) else 0
             self.config.useFloat16 = self.use_fp16
             if use_ip:
                 self.index = faiss.GpuIndexFlatIP(self.res, d, self.config)  # ty: ignore[possibly-missing-attribute]

--- a/uv.lock
+++ b/uv.lock
@@ -342,6 +342,27 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/34/6b04ef5bae3eada6b5a9457d7875cce041c040d53c890815cbd1e9821c65/faiss_cpu-1.14.3-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:f9d0e84d909194f63f027bbd3c1e35e905e48c9345c2db6e6f24da09a6bc5906", size = 6925734, upload-time = "2026-06-13T02:19:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/b451af4b3c6dd18749ecfb58ccb68503b77e49c9aa4a89d950e9d521e058/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d734cfa9ac90b6a5dfed3a27cb706d05f22824703dafc3969b4e2071877a31c", size = 9661210, upload-time = "2026-06-13T02:19:06.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ed/57335bc18c9e18677587bec9bf070c675b29c8e683e13f4def0440731ca0/faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8780b526c06e57aad90a8c4655dfba2ff1b3195bd600ff4499752fc45159c9fc", size = 18506292, upload-time = "2026-06-13T02:19:09.621Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/c6ca8c44a63b909e78aa8a69e14501c79c89613e62261d58455ea603d710/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b28ba083e8c02f2c9be03783402537fd3f00d27e68799c44bf88931500ee12ec", size = 11238800, upload-time = "2026-06-13T02:19:12.821Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/b405692913a301251749cb175cb3f564ed257fdaa80a22c9a36444d0095d/faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdcb90850cb4b7c27d270839b37bcc0dc8d1fb6a62d1e13053e51ac95061ca25", size = 19237637, upload-time = "2026-06-13T02:19:15.531Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6c/bbf670ad727502102fa90c52f9b47c73753f0adda880d30427ac1d48b37b/faiss_cpu-1.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:f278003d00c30c90cf118b98428bb96f73eba4b9dadac6993c788966d2e983bd", size = 16159350, upload-time = "2026-06-13T02:19:20.601Z" },
+    { url = "https://files.pythonhosted.org/packages/59/aa/bfa53255a6aa6e79b2471bb5af895f662feb02b612e1e0f9efc3d893286e/faiss_cpu-1.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:0a5eb27184123c7ac1060c6b862978eabf0e30c1369ccf8bdb1497d35c06ad3d", size = 16164699, upload-time = "2026-06-13T02:19:22.969Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c1/2fb14f58ff74d7a7d6fd13084c016d9b144ce0bcdf77f6526cc2e4828278/faiss_cpu-1.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:ea2340f675db59af8db6da4535b541ce6948d68a008989c656c292c7b0c77127", size = 16162836, upload-time = "2026-06-13T02:19:25.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/aa/100d3b706b8e2aa561e2673ed7d07c4c7c26f92d938a88d193dd54f90c45/faiss_cpu-1.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:54b0ea832be5bce75ef9abf1297fe4613d760bf7cfe7a963da040cb0314e8f58", size = 16444608, upload-time = "2026-06-13T02:19:27.992Z" },
+]
+
+[[package]]
 name = "faiss-cuda"
 version = "1.14.1.post3"
 source = { registry = "https://pypi.org/simple" }
@@ -377,10 +398,10 @@ wheels = [
 
 [[package]]
 name = "faissknn"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "faiss-cuda-cu128" },
+    { name = "faiss-cpu" },
     { name = "numpy" },
     { name = "torch" },
 ]
@@ -388,6 +409,9 @@ dependencies = [
 [package.optional-dependencies]
 cu13 = [
     { name = "faiss-cuda" },
+]
+cuda = [
+    { name = "faiss-cuda-cu128" },
 ]
 
 [package.dev-dependencies]
@@ -404,12 +428,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "faiss-cpu", specifier = ">=1.8,<2" },
     { name = "faiss-cuda", marker = "extra == 'cu13'", specifier = ">=1.14.1.post3,<2" },
-    { name = "faiss-cuda-cu128", specifier = ">=1.14.1.post1,<2" },
+    { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post1,<2" },
     { name = "numpy", specifier = ">=2,<3" },
     { name = "torch", specifier = ">=2,<3" },
 ]
-provides-extras = ["cu13"]
+provides-extras = ["cu13", "cuda"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Why

`pip install faissknn` previously hard-depended on `faiss-cuda-cu128`, which only publishes **Linux x86_64** wheels — so installs failed on macOS entirely. Flipping the default to `faiss-cpu` (which ships macOS arm64/x86_64, Linux, and Windows wheels) makes the default install work everywhere, and turns GPU acceleration into an explicit opt-in.

## Changes

- **Base dep:** `faiss-cuda-cu128` → `faiss-cpu>=1.8,<2`
- **New `[cuda]` extra:** `faiss-cuda-cu128` (CUDA 12.8)
- **Kept `[cu13]` extra:** `faiss-cuda` (CUDA 13 / Blackwell `sm_100`)
- **README:** default install now CPU; new "GPU acceleration" section + swap recipes. All three packages ship the same `faiss/` module and can't coexist, so each GPU extra documents `uninstall faiss-cpu → force-reinstall <gpu wheel>`.
- **CI:** test job now runs the **default install** across an OS matrix (`ubuntu` / `macos` / `windows`) instead of `--all-extras`, which pulled the Linux-only GPU wheels and collided on the `faiss` module. Dropped `--all-extras` from pre-commit too.
- **Typing:** faiss-cpu's stubs type `GpuIndexFlatConfig.device` as `int`; narrowed `self.device` to a definite int ordinal at the assignment site.
- **Version:** `0.1.1` → `0.2.0` (minor — pre-1.0, API unchanged, but default-backend behavior changes).

## Verified locally
- CPU import clean: `faiss 1.14.3`, `get_num_gpus() == 0`, `faissknn` imports
- `pytest`: 19 passed
- `pre-commit run --all-files`: all hooks pass (ruff, ty, mdformat, …)

macOS/Windows wheels validated by this PR's CI matrix.

https://claude.ai/code/session_01APCB2u3rtWvTtA8PeriMcH