### PR TITLE
feat: require explicit FAISS backend extra (no base faiss dep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,35 @@
 
 ### Install
 
+`faissknn` needs a FAISS backend, which you choose at install time via an extra. Pick **exactly one** — they ship the same `faiss` module and can't coexist. For CPU (works everywhere — macOS, Windows, Linux; no GPU, CUDA driver, or system toolkit required):
+
 ```bash
-pip install faissknn
+pip install "faissknn[cpu]"
 ```
 
-Pulls in [`faiss-cpu`](https://pypi.org/project/faiss-cpu/) along with `numpy` and `torch`. Works everywhere — no GPU, CUDA driver, or system toolkit required.
+This pulls in [`faiss-cpu`](https://pypi.org/project/faiss-cpu/) along with `numpy` and `torch`.
+
+> A bare `pip install faissknn` installs no FAISS backend and raises a clear error at import time telling you to pick an extra. Always install one of `[cpu]`, `[cuda]`, or `[cu13]`.
 
 #### GPU acceleration (CUDA 12.x)
 
-For GPU-enabled FAISS on CUDA 12.x hosts (NVIDIA driver R525+), install the `[cuda]` extra, which adds [`faiss-cuda-cu128`](https://pypi.org/project/faiss-cuda-cu128/) (Taylor Geospatial's GPU wheels for CUDA 12.8). No system CUDA toolkit needed — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI.
+For GPU-enabled FAISS on CUDA 12.x hosts (NVIDIA driver R525+), use the `[cuda]` extra, which installs [`faiss-cuda-cu128`](https://pypi.org/project/faiss-cuda-cu128/) (Taylor Geospatial's GPU wheels for CUDA 12.8) instead of `faiss-cpu`. No system CUDA toolkit needed — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI.
 
 ```bash
 pip install "faissknn[cuda]"
-pip uninstall -y faiss-cpu
-pip install --force-reinstall faiss-cuda-cu128
 ```
 
-These wheels also run on CUDA 13 hosts (driver R580+) via NVIDIA's forward-compat guarantee — you just don't get the `sm_100` (Blackwell) arch.
+These wheels (Linux x86_64) also run on CUDA 13 hosts (driver R580+) via NVIDIA's forward-compat guarantee — you just don't get the `sm_100` (Blackwell) arch.
 
 #### Blackwell users (B100 / B200)
 
-If you need `sm_100` baked in, use the CUDA 13 wheel via the `[cu13]` extra, which adds [`faiss-cuda`](https://pypi.org/project/faiss-cuda/):
+If you need `sm_100` baked in, use the CUDA 13 wheel via the `[cu13]` extra, which installs [`faiss-cuda`](https://pypi.org/project/faiss-cuda/):
 
 ```bash
 pip install "faissknn[cu13]"
-pip uninstall -y faiss-cpu
-pip install --force-reinstall faiss-cuda
 ```
 
-Why the uninstall+reinstall? `faiss-cpu`, `faiss-cuda-cu128`, and `faiss-cuda` all ship the same `faiss/` module, so they can't cleanly coexist. The extra adds the GPU package to the resolution, but removing `faiss-cpu` and force-reinstalling is what actually gives you a clean GPU install. uv/pip can't auto-detect the host CUDA driver, so this is a one-time manual choice.
+uv/pip can't auto-detect the host CUDA driver, so the backend is a manual choice. Because nothing is installed until you pick an extra, a **fresh** install of any single extra is clean — no base `faiss-cpu` to fight, no uninstall/reinstall dance. If you later want to **switch** backends in the same environment, uninstall the current one first (e.g. `pip uninstall -y faiss-cpu`) before installing the other extra, since the FAISS packages share the `faiss` module and can't coexist.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.9.3,<0.10" ]
 
 [project]
 name = "faissknn"
-version = "0.2.0"
+version = "0.3.0"
 description = "FAISS implementation of multiclass and multilabel K-Nearest Neighbors Classifiers."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -22,28 +22,30 @@ classifiers = [
 ]
 
 dependencies = [
-  # faiss-cpu is the default backend — works everywhere with no GPU, CUDA
-  # driver, or system toolkit required. For GPU acceleration, install an
-  # opt-in CUDA extra ([cuda] or [cu13]) and follow the swap recipe in the
-  # README (the CUDA wheels ship the same `faiss` module as faiss-cpu and
-  # cannot cleanly coexist, so the extra is a one-time manual choice).
-  "faiss-cpu>=1.8,<2",
+  # No FAISS backend is pinned here on purpose: faiss-cpu and the GPU wheels
+  # (faiss-cuda-cu128 / faiss-cuda) all ship the same `faiss` module and can't
+  # coexist. Users pick exactly one backend via an extra ([cpu], [cuda], or
+  # [cu13]), so there's never an install-then-uninstall swap. A bare install
+  # with no extra raises a clear, actionable error at import time (see knn.py).
   "numpy>=2,<3",
   "torch>=2,<3",
 ]
 
-# Opt-in GPU backends. uv/pip can't introspect the host CUDA driver, so the
-# choice is manual. faiss-cpu, faiss-cuda-cu128, and faiss-cuda all provide
-# the same `faiss` Python module and cannot cleanly coexist; follow the swap
-# recipe in the README.
-#   * cuda  -> faiss-cuda-cu128 (CUDA 12.8 wheels, driver R525+; also runs on
-#              CUDA 13 via NVIDIA forward-compat, minus the sm_100 arch)
-#   * cu13  -> faiss-cuda (CUDA 13 wheels with sm_100/Blackwell baked in)
+# Pick exactly one FAISS backend — they cannot coexist (same `faiss` module).
+# uv/pip can't introspect the host CUDA driver, so the choice is manual.
+#   * cpu   -> faiss-cpu        (all platforms incl. macOS/Windows; the default)
+#   * cuda  -> faiss-cuda-cu128 (CUDA 12.8 wheels, driver R525+; Linux x86_64;
+#              also runs on CUDA 13 via NVIDIA forward-compat, minus sm_100)
+#   * cu13  -> faiss-cuda       (CUDA 13 wheels with sm_100/Blackwell; Linux)
+optional-dependencies.cpu = [ "faiss-cpu>=1.8,<2" ]
 optional-dependencies.cu13 = [ "faiss-cuda>=1.14.1.post3,<2" ]
 optional-dependencies.cuda = [ "faiss-cuda-cu128>=1.14.1.post1,<2" ]
 
 [dependency-groups]
 dev = [
+  # Concrete backend for local dev + CI; end users choose via the [cpu]/[cuda]/
+  # [cu13] extras instead.
+  "faiss-cpu>=1.8,<2",
   "ipykernel>=7.0.1",
   "ipywidgets>=8.1.7",
   "pre-commit>=4.3",

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -2,8 +2,22 @@
 
 from typing import Any, Literal, Self
 
-import faiss
 import numpy as np
+
+try:
+    import faiss
+except ModuleNotFoundError as e:  # pragma: no cover
+    # faissknn intentionally pins no FAISS backend (the cpu/cuda wheels share
+    # the same `faiss` module and can't coexist). Turn the bare ImportError
+    # into an actionable message naming the extras the user must choose from.
+    msg = (
+        "faissknn requires a FAISS backend, which is not installed. "
+        "Install exactly one of the optional extras:\n"
+        "  pip install 'faissknn[cpu]'   # CPU — all platforms (the default)\n"
+        "  pip install 'faissknn[cuda]'  # GPU — CUDA 12.x, Linux x86_64\n"
+        "  pip install 'faissknn[cu13]'  # GPU — CUDA 13 / Blackwell, Linux"
+    )
+    raise ModuleNotFoundError(msg) from e
 
 # torch is a hard runtime dependency of this package, but be defensive in
 # case anyone uses faissknn in a torch-free env (e.g. mocked imports).

--- a/uv.lock
+++ b/uv.lock
@@ -398,15 +398,17 @@ wheels = [
 
 [[package]]
 name = "faissknn"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "faiss-cpu" },
     { name = "numpy" },
     { name = "torch" },
 ]
 
 [package.optional-dependencies]
+cpu = [
+    { name = "faiss-cpu" },
+]
 cu13 = [
     { name = "faiss-cuda" },
 ]
@@ -416,6 +418,7 @@ cuda = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "faiss-cpu" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "pre-commit" },
@@ -428,16 +431,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "faiss-cpu", specifier = ">=1.8,<2" },
+    { name = "faiss-cpu", marker = "extra == 'cpu'", specifier = ">=1.8,<2" },
     { name = "faiss-cuda", marker = "extra == 'cu13'", specifier = ">=1.14.1.post3,<2" },
     { name = "faiss-cuda-cu128", marker = "extra == 'cuda'", specifier = ">=1.14.1.post1,<2" },
     { name = "numpy", specifier = ">=2,<3" },
     { name = "torch", specifier = ">=2,<3" },
 ]
-provides-extras = ["cu13", "cuda"]
+provides-extras = ["cpu", "cu13", "cuda"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "faiss-cpu", specifier = ">=1.8,<2" },
     { name = "ipykernel", specifier = ">=7.0.1" },
     { name = "ipywidgets", specifier = ">=8.1.7" },
     { name = "pre-commit", specifier = ">=4.3" },


### PR DESCRIPTION
## Why

Follow-up to #8. Previously `faiss-cpu` was a **base** dependency, so opting into GPU (`[cuda]`/`[cu13]`) meant `pip install` then a manual `uninstall faiss-cpu → force-reinstall` dance, because all the FAISS packages share the `faiss/` module and can't coexist.

This removes faiss from the base deps entirely, turning the backend into a clean, mutually-exclusive **install-time choice**.

## Changes

- **Base deps:** drop `faiss-cpu` → just `numpy`, `torch`
- **Extras (pick exactly one):**
  - `[cpu]` → `faiss-cpu` (all platforms — the default)
  - `[cuda]` → `faiss-cuda-cu128` (CUDA 12.8, Linux x86_64)
  - `[cu13]` → `faiss-cuda` (CUDA 13 / Blackwell, Linux)
- **Import guard:** a bare `pip install faissknn` installs no backend; `knn.py` converts the `ModuleNotFoundError` into an actionable message naming the extras (verified locally).
- **Dev group:** `faiss-cpu` added so `uv run --dev` (local + CI) keeps a working backend.
- **README:** default install is now `pip install "faissknn[cpu]"`; the uninstall/reinstall dance is gone for fresh installs. Switching backends in an existing env still documents an uninstall-first step (pip extras are additive and won't remove the old package).
- **Version:** `0.2.0` → `0.3.0`.

> [!WARNING]
> **Breaking:** `pip install faissknn` no longer pulls a FAISS backend. Use `pip install "faissknn[cpu]"` (or `[cuda]`/`[cu13]`).

## Verified locally
- `pytest`: 19 passed
- `pre-commit run --all-files`: all hooks pass (ruff, ty, mdformat, …)
- Import guard fires with the correct message when no faiss is installed

OS matrix (ubuntu/macos/windows) validated by this PR's CI.

https://claude.ai/code/session_01APCB2u3rtWvTtA8PeriMcH