### PR TITLE
Import torch before faiss; correct wheel arch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This pulls in [`faiss-cpu`](https://pypi.org/project/faiss-cpu/) along with `num
 
 #### GPU acceleration
 
-On Linux x86_64 with an NVIDIA driver (R525+), use the `[cuda]` extra, which installs [`faiss-cuda`](https://pypi.org/project/faiss-cuda/) (Taylor Geospatial's GPU wheels, CUDA 12.8, arch sm_70–sm_120: V100 through B200/RTX-50) instead of `faiss-cpu`. No system CUDA toolkit needed — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI. The GPU wheel contains the full CPU implementation too, so it also works on GPU-less machines.
+On Linux x86_64 with an NVIDIA driver (R525+), use the `[cuda]` extra, which installs [`faiss-cuda`](https://pypi.org/project/faiss-cuda/) (Taylor Geospatial's GPU wheels, CUDA 12.8, arch sm_70/80/86/89/90: V100, A100, A10/A30/RTX-30, RTX-40, H100/H200 — T4/Blackwell/RTX-50 pending [a PyPI size-limit increase](https://github.com/pypi/support/issues/11444)) instead of `faiss-cpu`. No system CUDA toolkit needed — the runtime libraries come from `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` on PyPI. The GPU wheel contains the full CPU implementation too, so it also works on GPU-less machines.
 
 ```bash
 pip install "faissknn[cuda]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.9.3,<0.10" ]
 
 [project]
 name = "faissknn"
-version = "0.4.0"
+version = "0.4.1"
 description = "FAISS implementation of multiclass and multilabel K-Nearest Neighbors Classifiers."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -1,20 +1,25 @@
 """FAISS-based KNN classifiers for multiclass and multilabel classification."""
 
+import sys
 from typing import Any, Literal, Self
 
 import numpy as np
 
-# torch must be imported before faiss: faiss-cuda preloads CUDA 12 libraries,
-# and letting a CUDA 13 torch load first keeps each stack resolving its own
-# symbols (importing faiss first segfaulted on V100 + torch cu130; see
-# torchgeo/torchgeo-bench#152).
-try:
-    import torch
 
-    _TORCH_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    torch = None  # type: ignore[assignment]
-    _TORCH_AVAILABLE = False
+def _try_import_torch():
+    try:
+        import torch
+    except ImportError:  # pragma: no cover
+        return None
+    return torch
+
+
+# The safe torch/faiss import order differs by platform. On Linux, torch must
+# load before faiss: faiss-cuda preloads CUDA 12 libraries, and a CUDA 13
+# torch imported afterwards can bind them (segfault on V100 + torch cu130;
+# torchgeo/torchgeo-bench#152). On macOS the reverse order is required —
+# torch-first segfaults faiss-cpu at import (duplicate OpenMP runtimes).
+torch = _try_import_torch() if sys.platform == "linux" else None
 
 try:
     import faiss
@@ -29,6 +34,10 @@ except ModuleNotFoundError as e:  # pragma: no cover
         "  pip install 'faissknn[cuda]'  # GPU — NVIDIA, Linux x86_64"
     )
     raise ModuleNotFoundError(msg) from e
+
+if torch is None:
+    torch = _try_import_torch()
+_TORCH_AVAILABLE = torch is not None
 
 if _TORCH_AVAILABLE:
     try:

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -4,6 +4,18 @@ from typing import Any, Literal, Self
 
 import numpy as np
 
+# torch must be imported before faiss: faiss-cuda preloads CUDA 12 libraries,
+# and letting a CUDA 13 torch load first keeps each stack resolving its own
+# symbols (importing faiss first segfaulted on V100 + torch cu130; see
+# torchgeo/torchgeo-bench#152).
+try:
+    import torch
+
+    _TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore[assignment]
+    _TORCH_AVAILABLE = False
+
 try:
     import faiss
 except ModuleNotFoundError as e:  # pragma: no cover
@@ -18,16 +30,11 @@ except ModuleNotFoundError as e:  # pragma: no cover
     )
     raise ModuleNotFoundError(msg) from e
 
-# torch is a hard runtime dependency of this package, but be defensive in
-# case anyone uses faissknn in a torch-free env (e.g. mocked imports).
-try:
-    import faiss.contrib.torch_utils  # monkey-patches faiss add/search
-    import torch
-
-    _TORCH_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    torch = None  # type: ignore[assignment]
-    _TORCH_AVAILABLE = False
+if _TORCH_AVAILABLE:
+    try:
+        import faiss.contrib.torch_utils  # monkey-patches faiss add/search
+    except ImportError:  # pragma: no cover
+        _TORCH_AVAILABLE = False
 
 Metric = Literal["l2", "ip", "cosine"]
 

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -1,12 +1,13 @@
 """FAISS-based KNN classifiers for multiclass and multilabel classification."""
 
 import sys
+import types
 from typing import Any, Literal, Self
 
 import numpy as np
 
 
-def _try_import_torch():
+def _try_import_torch() -> types.ModuleType | None:
     try:
         import torch
     except ImportError:  # pragma: no cover

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -1,13 +1,12 @@
 """FAISS-based KNN classifiers for multiclass and multilabel classification."""
 
 import sys
-import types
 from typing import Any, Literal, Self
 
 import numpy as np
 
 
-def _try_import_torch() -> types.ModuleType | None:
+def _try_import_torch() -> Any:
     try:
         import torch
     except ImportError:  # pragma: no cover

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "faissknn"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Follow-ups from calebrob6's V100 report on torchgeo/torchgeo-bench#152. Importing faiss (which preloads CUDA 12 libs) before a CUDA 13 torch segfaulted on his V100 box, so torch now loads first — the order he verified safe. Also corrects the README arch claim: current PyPI wheels are sm_70/80/86/89/90 until the size-limit bump lands.