### PR TITLE
Prune comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,22 +22,17 @@ classifiers = [
 ]
 
 dependencies = [
-  # No FAISS backend pinned on purpose: users pick one via [cpu] or [cuda].
-  # A bare install raises an actionable error at import time (see knn.py).
+  # No FAISS backend on purpose: pick one via [cpu] or [cuda].
   "numpy>=2,<3",
   "torch>=2,<3",
 ]
 
-# Pick exactly one FAISS backend — faiss-cpu and faiss-cuda ship the same
-# `faiss` module and cannot coexist. faiss-cuda (Linux x86_64, driver R525+)
-# also works on GPU-less machines.
+# Backends ship the same `faiss` module and cannot coexist — install exactly one.
 optional-dependencies.cpu = [ "faiss-cpu>=1.8,<2" ]
 optional-dependencies.cuda = [ "faiss-cuda>=1.14.3,<2" ]
 
 [dependency-groups]
 dev = [
-  # Concrete backend for local dev + CI; end users choose via the [cpu]/[cuda]/
-  # [cu13] extras instead.
   "faiss-cpu>=1.8,<2",
   "ipykernel>=7.0.1",
   "ipywidgets>=8.1.7",

--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -6,17 +6,11 @@ from typing import Any, Literal, Self
 import numpy as np
 
 if sys.platform == "linux":
-    # Import order is load-bearing: a CUDA 13 torch must load before
-    # faiss-cuda's CUDA 12 preload, while on macOS torch-first crashes
-    # faiss-cpu's OpenMP (torchgeo/torchgeo-bench#152).
-    import torch
+    import torch  # before faiss on linux, after on macos (torchgeo/torchgeo-bench#152)
 
 try:
     import faiss
 except ModuleNotFoundError as e:  # pragma: no cover
-    # faissknn intentionally pins no FAISS backend (the cpu/cuda wheels share
-    # the same `faiss` module and can't coexist). Turn the bare ImportError
-    # into an actionable message naming the extras the user must choose from.
     msg = (
         "faissknn requires a FAISS backend, which is not installed. "
         "Install exactly one of the optional extras:\n"


### PR DESCRIPTION
Trims the backend/import comments to one-liners; the code and error messages carry the rest.