### PR TITLE
fix: sync torch device context around GPU faiss calls

### DIFF
--- a/src/faissknn/knn.py
+++ b/src/faissknn/knn.py
@@ -1,5 +1,6 @@
 """FAISS-based KNN classifiers for multiclass and multilabel classification."""
 
+import contextlib
 import sys
 from typing import Any, Literal, Self
 
@@ -87,6 +88,19 @@ class FaissKNNClassifier:
             else:
                 self.device = 0
 
+    def _device_ctx(self) -> contextlib.AbstractContextManager:
+        """Context manager that sets torch's current device to the index's GPU.
+
+        ``faiss.contrib.torch_utils`` reads ``torch.cuda.current_device()`` to
+        decide which stream to sync faiss against (see issue #14). Without
+        this, a GPU index on a non-default device races against torch's
+        producing/consuming kernels on any other current device, silently
+        corrupting results. A no-op on CPU.
+        """
+        if self.cuda:
+            return torch.cuda.device(self.device)
+        return contextlib.nullcontext()
+
     def _as_index_input(self, X: Any) -> Any:
         """Coerce input for FAISS ingestion + apply metric-specific prep.
 
@@ -164,7 +178,8 @@ class FaissKNNClassifier:
         """
         X = self._as_index_input(X)
         self.create_index(X.shape[-1])
-        self.index.add(X)  # type: ignore[arg-type]
+        with self._device_ctx():
+            self.index.add(X)  # type: ignore[arg-type]
         if isinstance(y, torch.Tensor):
             y = y.detach().cpu().numpy()
         self.y = y.astype(int)
@@ -202,7 +217,8 @@ class FaissKNNClassifier:
             Predicted integer class labels, shape (n_samples,).
         """
         X = self._as_index_input(X)
-        _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
+        with self._device_ctx():
+            _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         idx = self._idx_to_numpy(idx)
         class_idx = self.y[idx]
         return np.argmax(self._class_counts(class_idx), axis=1)
@@ -221,7 +237,8 @@ class FaissKNNClassifier:
             Predicted class probabilities, shape (n_samples, n_classes).
         """
         X = self._as_index_input(X)
-        _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
+        with self._device_ctx():
+            _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         idx = self._idx_to_numpy(idx)
         class_idx = self.y[idx]
         return self._class_counts(class_idx) / self.n_neighbors
@@ -233,7 +250,8 @@ class FaissKNNMultilabelClassifier(FaissKNNClassifier):
     def _neighbor_label_sums(self, X: Any) -> np.ndarray:
         """Per-query, per-label count of positive (``==1``) neighbors."""
         X = self._as_index_input(X)
-        _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
+        with self._device_ctx():
+            _, idx = self.index.search(X, k=self.n_neighbors)  # type: ignore[missing-argument]
         idx = self._idx_to_numpy(idx)
         # self.y[idx] -> (N, k, L) with values in {0, 1}; sum over k gives
         # count of 1s per (query, label).

--- a/tests/test_gpu_stream_ordering.py
+++ b/tests/test_gpu_stream_ordering.py
@@ -14,9 +14,11 @@ still being produced by pending matmuls on torch's stream when
 
 import numpy as np
 import pytest
-import torch
 
-from faissknn import FaissKNNClassifier
+from faissknn import FaissKNNClassifier  # before torch on macOS (see knn.py)
+
+# isort: split
+import torch
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,

--- a/tests/test_gpu_stream_ordering.py
+++ b/tests/test_gpu_stream_ordering.py
@@ -1,0 +1,58 @@
+"""Regression test for GH #14: GPU search not stream-ordered off cuda:0.
+
+``faiss.contrib.torch_utils`` syncs faiss's stream against
+``torch.cuda.current_device()``, not the device the index actually lives
+on. Selecting a non-default GPU the idiomatic way (``.to("cuda:N")``, no
+device context) left faiss's search racing against torch's producing /
+consuming kernels, silently corrupting results on any GPU other than
+``cuda:0``. See the issue for the full root-cause writeup.
+
+This reproduces the race from the issue's repro script: a query tensor is
+still being produced by pending matmuls on torch's stream when
+``FaissKNNClassifier.predict`` is called on a non-default device.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from faissknn import FaissKNNClassifier
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="requires at least 2 CUDA GPUs to exercise a non-default device",
+)
+
+
+def _pending_query(q: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    """Return a tensor equal to ``q`` but only once queued matmuls finish."""
+    h = q
+    for _ in range(8):
+        h = h @ w
+    return q + 0.0 * h[:, :1]
+
+
+@pytest.mark.parametrize("dev", ["cuda:1"])
+def test_gpu_predict_matches_cpu_off_default_device(dev: str) -> None:
+    """predict() on a non-default GPU must match the CPU reference every time.
+
+    Before the fix this flipped on essentially every call: faiss's search
+    ran on the index's private cuda:1 stream while the query tensor was
+    still being written by pending matmuls on torch's current (cuda:0)
+    stream, and the result read back before faiss finished writing it.
+    """
+    torch.manual_seed(0)
+    n_train, n_test, d, n_classes, k = 2000, 200, 256, 10, 5
+
+    x_train = torch.randn(n_train, d)
+    y_train = torch.randint(0, n_classes, (n_train,))
+    x_test = torch.randn(n_test, d)
+
+    ref = FaissKNNClassifier(n_neighbors=k, device="cpu").fit(x_train, y_train).predict(x_test)
+
+    clf = FaissKNNClassifier(n_neighbors=k, device=dev).fit(x_train.to(dev), y_train)
+    w = torch.randn(d, d, device=dev)
+
+    for _ in range(20):
+        pred = clf.predict(_pending_query(x_test.to(dev), w))
+        np.testing.assert_array_equal(pred, ref)


### PR DESCRIPTION
## Summary
- On a GPU index living on a non-default device (e.g. `cuda:1`), `faiss.contrib.torch_utils` syncs faiss's stream against `torch.cuda.current_device()` rather than the index's actual device, so `fit`/`predict`/`predict_proba` could race against pending torch kernels on the caller's current stream and silently return wrong neighbours (occasionally an out-of-range `IndexError`).
- Wraps every GPU-path call into faiss (`index.add`, `index.search` in `predict`, `predict_proba`, and the multilabel `_neighbor_label_sums`) in `torch.cuda.device(self.device)` so `torch_utils`'s stream sync targets the right device. No-op on CPU.

## Test plan
- [x] `pytest tests/` green on CPU (19 passed, 1 skipped — the new GPU-only regression test)
- [x] GPU validation on 2x H100 (RAILS): full suite 20/20 passed, including the new `tests/test_gpu_stream_ordering.py` regression test reproducing the issue's exact repro (pending torch matmuls + `cuda:1`)

Also audited every other torch↔faiss boundary crossing in `knn.py` (cosine-normalize, `.cpu()` in `_idx_to_numpy`, `__del__` teardown) for similar latent races — none found; all are either same-stream-ordered or not routed through `torch_utils`.

Fixes #14